### PR TITLE
Fixes for Yocto release Fido and Weston 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,19 @@ This layer is unofficial.
 
 This layer depends on:
 
+URI: git://git.yoctoproject.org/poky.git
+branch: fido
+revision: HEAD
+
 URI: git://github.com/agherzan/meta-raspberrypi.git
 branch: master
 revision: HEAD
 
 Main layer maintainers:
   Yusuke Mitsuki <mickey.happygolucky@gmail.com>
+
+Contributors:
+  Leon Anavi <leon@anavi.org>
 
 A porting of wayland-egl is important factor of this layer.
 https://github.com/albertd/buildroot-rpi was very helpful. Thanks.

--- a/recipes-gnome/gtk+/gtk+3_%.bbappend
+++ b/recipes-gnome/gtk+/gtk+3_%.bbappend
@@ -1,0 +1,6 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+CFLAGS +=" -I${STAGING_DIR_TARGET}/usr/include/interface/vcos/pthreads \
+             -I${STAGING_DIR_TARGET}/usr/include/interface/vmcs_host/linux \
+           "
+

--- a/recipes-graphics/userland/userland/0001-wayland-support.patch
+++ b/recipes-graphics/userland/userland/0001-wayland-support.patch
@@ -30,42 +30,6 @@ diff -Narubp a/README.md b/README.md
 +To build support for the Wayland winsys in EGL, execute the buildme script like this:
 +
 +$ BUILD_WAYLAND=1 ./buildme.
-diff -Narubp a/buildme b/buildme
---- a/buildme	2015-02-28 08:44:03.144718163 +0900
-+++ b/buildme	2015-02-28 10:38:02.852914891 +0900
-@@ -1,10 +1,14 @@
- #/bin/bash
- 
-+if [ -n "$BUILD_WAYLAND" ]; then
-+	WAYLAND_VARS="-DBUILD_WAYLAND=TRUE"
-+fi
-+
- if [ "armv6l" = `arch` ]; then
- 	# Native compile on the Raspberry Pi
- 	mkdir -p build/raspberry/release
- 	pushd build/raspberry/release
--	cmake -DCMAKE_BUILD_TYPE=Release ../../..
-+	cmake -DCMAKE_BUILD_TYPE=Release $WAYLAND_VARS ../../..
- 	make
- 	if [ "$1" != "" ]; then
- 	 sudo make install DESTDIR=$1
-@@ -13,9 +17,15 @@ if [ "armv6l" = `arch` ]; then
- 	fi
- else
- 	# Cross compile on a more capable machine
-+
-+	if [ -n "$BUILD_WAYLAND" ]; then
-+		# Use wayland-scanner from the build platform
-+		WAYLAND_VARS+=" -DWAYLAND_SCANNER_EXECUTABLE:FILEPATH=/usr/bin/wayland-scanner"
-+	fi
-+
- 	mkdir -p build/arm-linux/release/
- 	pushd build/arm-linux/release/
--	cmake -DCMAKE_TOOLCHAIN_FILE=../../../makefiles/cmake/toolchains/arm-linux-gnueabihf.cmake -DCMAKE_BUILD_TYPE=Release ../../..
-+	cmake -DCMAKE_TOOLCHAIN_FILE=../../../makefiles/cmake/toolchains/arm-linux-gnueabihf.cmake -DCMAKE_BUILD_TYPE=Release $WAYLAND_VARS ../../..
- 	make -j 6
- 
- 	if [ "$1" != "" ]; then
 diff -Narubp a/interface/khronos/CMakeLists.txt b/interface/khronos/CMakeLists.txt
 --- a/interface/khronos/CMakeLists.txt	2015-02-28 08:44:03.332718168 +0900
 +++ b/interface/khronos/CMakeLists.txt	2015-02-28 10:38:02.820914890 +0900

--- a/recipes-graphics/userland/userland/buildme.patch
+++ b/recipes-graphics/userland/userland/buildme.patch
@@ -1,0 +1,37 @@
+diff --git a/buildme b/buildme
+index d5d3de9..a1c440e 100755
+--- a/buildme
++++ b/buildme
+@@ -1,10 +1,14 @@
+ #!/bin/bash
+ 
++if [ -n "$BUILD_WAYLAND" ]; then
++	WAYLAND_VARS="-DBUILD_WAYLAND=TRUE"
++fi
++
+ if [ "armv6l" = `arch` ] || [ "armv7l" = `arch` ]; then
+ 	# Native compile on the Raspberry Pi
+ 	mkdir -p build/raspberry/release
+ 	pushd build/raspberry/release
+-	cmake -DCMAKE_BUILD_TYPE=Release ../../..
++	cmake -DCMAKE_BUILD_TYPE=Release $WAYLAND_VARS ../../..
+ 	if [ "armv6l" = `arch` ]; then
+ 		make
+ 	else
+@@ -17,9 +21,15 @@ if [ "armv6l" = `arch` ] || [ "armv7l" = `arch` ]; then
+ 	fi
+ else
+ 	# Cross compile on a more capable machine
++
++	if [ -n "$BUILD_WAYLAND" ]; then
++		# Use wayland-scanner from the build platform
++		WAYLAND_VARS+=" -DWAYLAND_SCANNER_EXECUTABLE:FILEPATH=/usr/bin/wayland-scanner"
++	fi
++
+ 	mkdir -p build/arm-linux/release/
+ 	pushd build/arm-linux/release/
+-	cmake -DCMAKE_TOOLCHAIN_FILE=../../../makefiles/cmake/toolchains/arm-linux-gnueabihf.cmake -DCMAKE_BUILD_TYPE=Release ../../..
++	cmake -DCMAKE_TOOLCHAIN_FILE=../../../makefiles/cmake/toolchains/arm-linux-gnueabihf.cmake -DCMAKE_BUILD_TYPE=Release $WAYLAND_VARS ../../..
+ 	make -j 6
+ 
+ 	if [ "$1" != "" ]; then

--- a/recipes-graphics/userland/userland_git.bbappend
+++ b/recipes-graphics/userland/userland_git.bbappend
@@ -8,6 +8,7 @@ SRC_URI += "file://egl.pc \
 	    file://glesv2.pc \
  	    file://bcm_host.pc \
 	    file://0001-wayland-support.patch \
+            file://buildme.patch \
 "
 
 EXTRA_OECMAKE += "-DBUILD_WAYLAND=1"

--- a/recipes-graphics/wayland/weston_%.bbappend
+++ b/recipes-graphics/wayland/weston_%.bbappend
@@ -1,0 +1,9 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+EXTRA_OECONF += " --enable-rpi-compositor \
+	     	  WESTON_NATIVE_BACKEND='rpi-backend.so' \
+		  "
+
+CFLAGS +=" -I${STAGING_DIR_TARGET}/usr/include/interface/vcos/pthreads \
+             -I${STAGING_DIR_TARGET}/usr/include/interface/vmcs_host/linux \
+           "

--- a/recipes-graphics/wayland/weston_1.6.0.bbappend
+++ b/recipes-graphics/wayland/weston_1.6.0.bbappend
@@ -1,5 +1,0 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
-
-EXTRA_OECONF += " --enable-rpi-compositor \
-	     	  WESTON_NATIVE_BACKEND='rpi-backend.so' \
-		  "


### PR DESCRIPTION
Includes fixes of recipes for Weston and GTK+3. Tested with Yocto release Fido (version 13.0, Yocto project version 1.8)
